### PR TITLE
make test scripts faster when the runner wants to filter tests

### DIFF
--- a/bundler/scripts/test.sh
+++ b/bundler/scripts/test.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -eux
 
-cargo test --lib
-cargo test --test fixture
-(cd ../spack && cargo test --test fixture)
+if [ -z "$@" ]; then
+    cargo test --lib
+    cargo test --test fixture
+    (cd ../spack && cargo test --test fixture)
+fi
+
 cargo test --test deno $@ -- --nocapture

--- a/ecmascript/minifier/scripts/run.sh
+++ b/ecmascript/minifier/scripts/run.sh
@@ -11,10 +11,12 @@
 #
 set -eu
 
-./scripts/sort.sh
+if [ -z "$@" ]; then
+    ./scripts/sort.sh
 
-export RUST_LOG=swc_ecma_minifier=trace
+    export RUST_LOG=swc_ecma_minifier=trace
 
-GOLDEN_ONLY=1 cargo test --test compress
+    GOLDEN_ONLY=1 cargo test --test compress
+fi
 
 cargo test --test compress $@


### PR DESCRIPTION
When developing the property mangler, I'd commented out the lines in this 'if' statement so I could run specific tests faster.

So I came up with this PR to enable us to filter tests when desired, and run them quickly, but also allow to run everything by omitting filter arguments.

If you have a better idea for testing quickly please let me know :) this is still pretty slow.