### PR TITLE
place private property mangler in the regular mangler

### DIFF
--- a/ecmascript/minifier/src/option/mod.rs
+++ b/ecmascript/minifier/src/option/mod.rs
@@ -55,6 +55,9 @@ pub struct MangleOptions {
     #[serde(default, alias = "keep_fnames")]
     pub keep_fn_names: bool,
 
+    #[serde(default, alias = "keep_private_props")]
+    pub keep_private_props: bool,
+
     #[serde(default, alias = "ie8")]
     pub ie8: bool,
 

--- a/ecmascript/minifier/src/pass/mangle_names/mod.rs
+++ b/ecmascript/minifier/src/pass/mangle_names/mod.rs
@@ -117,7 +117,7 @@ impl VisitMut for Mangler {
 
     fn visit_mut_private_name(&mut self, private_name: &mut PrivateName) {
         if !self.options.keep_private_props {
-           self.rename_private(private_name);
+            self.rename_private(private_name);
         }
     }
 

--- a/ecmascript/minifier/tests/terser/compress/properties/mangle_private_properties/mangle.json
+++ b/ecmascript/minifier/tests/terser/compress/properties/mangle_private_properties/mangle.json
@@ -1,4 +1,3 @@
 {
-    "properties": {},
     "toplevel": true
 }


### PR DESCRIPTION
This PR simply moves private property mangling to the regular mangler.

My reasoning for this is that the property mangler is supposed to be avoided since it is unsafe. The mangler, however, is perfectly safe.

Because private properties have such a clear scope and are totally safe to mangle, I've moved the code that mangles them.