### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/crates/swc_ecma_preset_env/Cargo.toml
+++ b/crates/swc_ecma_preset_env/Cargo.toml
@@ -7,6 +7,7 @@ include       = ["Cargo.toml", "src/**/*.rs", "src/**/*.json", "data/**/*.json"]
 license       = "Apache-2.0"
 name          = "swc_ecma_preset_env"
 version       = "0.198.3"
+repository    = "https://github.com/kdy1/swc"
 
 [lib]
 bench = false


### PR DESCRIPTION
One of the few crates that was missing this information.
You can check out the [list of your crates](https://rust-digger.code-maven.com/users/kdy1) on Rust digger to see if there are others missing the repository link.